### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,6 +8,7 @@
   ],
   "description" : "A bloom filter implementation in Perl 6",
   "name" : "Algorithm::BloomFilter",
+  "license" : "Artistic-2.0",
   "perl" : "6.c",
   "provides" : {
     "Algorithm::BloomFilter" : "lib/Algorithm/BloomFilter.pm6"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license