### PR TITLE
git: based source-url will cause a failure when installed via zef

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -14,7 +14,7 @@
     "Algorithm::BloomFilter" : "lib/Algorithm/BloomFilter.pm6"
   },
   "resources" : [ ],
-  "source-url" : "git@github.com:yowcow/p6-Algorithm-BloomFilter.git",
+  "source-url" : "https://github.com/yowcow/p6-Algorithm-BloomFilter.git",
   "test-depends" : [
     "Test",
     "Test::META"


### PR DESCRIPTION
- Fix source-url in META6.json